### PR TITLE
An implementation of whitespace preserving parsing

### DIFF
--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -102,11 +102,19 @@ fn byte_size(string: String) -> Int {
 pub fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
   case lexer.source {
     // Newline
-    "\r\n" <> rest -> newline(lexer, rest, 2)
-    "\n" <> rest -> newline(lexer, rest, 1)
+    // "\r\n" <> rest -> newline(lexer, rest, 2)
+    "\r\n" <> rest -> #(
+      advance(lexer, rest, 2),
+      token(lexer, token.Blank("\r\n")),
+    )
 
-    // Whitespace
-    " " <> rest | "\t" <> rest -> next(advance(lexer, rest, 1))
+    // "\n" <> rest -> newline(lexer, rest, 1)
+    "\n" <> rest -> #(advance(lexer, rest, 1), token(lexer, token.Blank("\n")))
+
+    // // Whitespace
+    // " " <> rest | "\t" <> rest -> next(advance(lexer, rest, 1))
+    " " <> rest -> #(advance(lexer, rest, 1), token(lexer, token.Blank(" ")))
+    "\t" <> rest -> #(advance(lexer, rest, 1), token(lexer, token.Blank("\t")))
 
     // Comments
     "////" <> rest -> comment(rest, lexer.position, 4, token.CommentModule)

--- a/src/glexer/token.gleam
+++ b/src/glexer/token.gleam
@@ -81,6 +81,7 @@ pub type Token {
   // Extra
   CommentNormal
   CommentModule
+  Blank(String)
   EmptyLine
 
   // Invalid code tokens

--- a/src/glexer/token.gleam
+++ b/src/glexer/token.gleam
@@ -79,8 +79,8 @@ pub type Token {
   EndOfFile
 
   // Extra
-  CommentNormal
-  CommentModule
+  CommentNormal(String)
+  CommentModule(String)
   Blank(String)
   EmptyLine
 


### PR DESCRIPTION
This is just a quick spike to show what I have changed. This changed code works for me and I am happy maintaining a fork.

Should I try and find a better way to integrate this? I'm happy to do more but not sure what the cleanest way is.
I don't think creating too different Token types which are the same only one has `Blank` and one has `EmptyLine` is the way to go.
I don't know what the usecase for tracking empty lines but not arbitrary whitespace is so I might need to understand that better before making a good API.