### PR TITLE
`to_source`, roundtrip tests

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,3 +13,4 @@ gleam_stdlib = ">= 0.43.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.1"
+simplifile = ">= 1.0.0 and < 3.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
   { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.43.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.1" }
+simplifile = { version = ">= 1.0.0 and < 3.0.0" }

--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -596,6 +596,13 @@ fn lex_string(
   }
 }
 
+/// Turn a sequence o tokens back to their Gleam source code representation.
+///
+pub fn to_source(tokens: List(#(Token, Position))) -> String {
+  use source, #(tok, _) <- list.fold(tokens, "")
+  source <> token.to_source(tok)
+}
+
 // ///////////////// //
 // Utility Functions //
 // ///////////////// //

--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -596,7 +596,7 @@ fn lex_string(
   }
 }
 
-/// Turn a sequence o tokens back to their Gleam source code representation.
+/// Turn a sequence of tokens back to their Gleam source code representation.
 ///
 pub fn to_source(tokens: List(#(Token, Position))) -> String {
   use source, #(tok, _) <- list.fold(tokens, "")

--- a/src/glexer/token.gleam
+++ b/src/glexer/token.gleam
@@ -94,3 +94,104 @@ pub type Token {
   UnterminatedString(String)
   UnexpectedGrapheme(String)
 }
+
+/// Turn a token back into its Gleam source representation.
+///
+pub fn to_source(tok: Token) -> String {
+  case tok {
+    // Literals
+    Name(str) -> str
+    UpperName(str) -> str
+    Int(str) -> str
+    Float(str) -> str
+    DiscardName(str) -> "_" <> str
+    String(str) -> "\"" <> str <> "\""
+    CommentDoc(str) -> "///" <> str
+    CommentNormal(str) -> "//" <> str
+    CommentModule(str) -> "////" <> str
+
+    // Keywords
+    As -> "as"
+    Assert -> "assert"
+    Auto -> "auto"
+    Case -> "case"
+    Const -> "const"
+    Delegate -> "delegate"
+    Derive -> "derive"
+    Echo -> "echo"
+    Else -> "else"
+    Fn -> "fn"
+    If -> "if"
+    Implement -> "implement"
+    Import -> "import"
+    Let -> "let"
+    Macro -> "macro"
+    Opaque -> "opaque"
+    Panic -> "panic"
+    Pub -> "pub"
+    Test -> "test"
+    Todo -> "todo"
+    Type -> "type"
+    Use -> "use"
+
+    // Groupings
+    LeftParen -> "("
+    RightParen -> ")"
+    LeftBrace -> "{"
+    RightBrace -> "}"
+    LeftSquare -> "["
+    RightSquare -> "]"
+
+    // Int Operators
+    Plus -> "+"
+    Minus -> "-"
+    Star -> "*"
+    Slash -> "/"
+    Less -> "<"
+    Greater -> ">"
+    LessEqual -> "<="
+    GreaterEqual -> ">="
+    Percent -> "%"
+
+    // Float Operators
+    PlusDot -> "+."
+    MinusDot -> "-."
+    StarDot -> "*."
+    SlashDot -> "/."
+    LessDot -> "<."
+    GreaterDot -> ">."
+    LessEqualDot -> "<=."
+    GreaterEqualDot -> ">=."
+
+    // String Operators
+    LessGreater -> "<>"
+
+    // Other Punctuation
+    At -> "@"
+    Colon -> ":"
+    Comma -> ","
+    Hash -> "#"
+    Bang -> "!"
+    Equal -> "="
+    EqualEqual -> "=="
+    NotEqual -> "!="
+    VBar -> "|"
+    VBarVBar -> "||"
+    AmperAmper -> "&&"
+    LessLess -> "<<"
+    GreaterGreater -> ">>"
+    Pipe -> "|>"
+    Dot -> "."
+    DotDot -> ".."
+    LeftArrow -> "<-"
+    RightArrow -> "->"
+    EndOfFile -> ""
+
+    // Extra
+    Space(str) -> str
+
+    // Invalid code tokens
+    UnterminatedString(str) -> "\"" <> str
+    UnexpectedGrapheme(str) -> str
+  }
+}

--- a/test/roundtrip_test.gleam
+++ b/test/roundtrip_test.gleam
@@ -1,0 +1,42 @@
+import gleam/bool
+import gleam/list
+import gleam/string
+import glexer
+import simplifile
+
+fn test_roundtrip(directory) {
+  let assert Ok(files) = simplifile.get_files(directory)
+  use file <- list.each(files)
+  use <- bool.guard(when: !string.ends_with(file, ".gleam"), return: Nil)
+  test_roundtrip_file(file)
+}
+
+fn test_roundtrip_file(filename) {
+  let assert Ok(file) = simplifile.read(filename)
+  let roundtripped =
+    glexer.new(file)
+    |> glexer.lex
+    |> glexer.to_source
+
+  use <- bool.guard(when: file == roundtripped, return: Nil)
+
+  // files are not equal - write the roundtripped file, then panic.
+  let received = filename <> ".received"
+  let assert Ok(_) = simplifile.write(received, roundtripped)
+  let msg = filename <> " could not roundtrip, wrote " <> received
+  panic as msg
+}
+
+pub fn roundtrip_self_test() {
+  test_roundtrip("src")
+  test_roundtrip("test")
+}
+
+pub fn roundtrip_stdlib_test() {
+  // duplicate, here to make extra sure that the stdandard lib code works.
+  test_roundtrip("build/packages/gleam_stdlib")
+}
+
+pub fn roundtrip_dependencies_test() {
+  test_roundtrip("build/packages")
+}


### PR DESCRIPTION
Adds a `to_source` function to the token and glexer modules, which turn a (list of) tokens back into their gleam source code representation.

Also adds some tests making sure that glexer can parse its own source code and the source of all its dependencies, and turn those back into the equivalent file again.