### PR TITLE
Improve lex perf on erlang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [2.3.0] - 2025-08-30
+
+-   Use `splitter` library to increase performance when lexing comments
+
+## [2.2.1] - 2025-03-18
 
 -   Fix issue when skipping a comment without a proceeding newline
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,3 +14,4 @@ gleam_stdlib = ">= 0.43.0 and < 1.0.0"
 [dev-dependencies]
 gleeunit = "~> 1.1"
 simplifile = ">= 1.0.0 and < 3.0.0"
+gleamy_bench = ">= 0.6.0 and < 1.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "glexer"
-version = "2.2.0"
+version = "2.3.0"
 description = "A lexer for Gleam source code"
 licenses = ["MIT"]
 gleam = ">= 1.4.0"
@@ -10,6 +10,7 @@ allow_read = true
 
 [dependencies]
 gleam_stdlib = ">= 0.43.0 and < 1.0.0"
+splitter = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.1"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,11 +4,13 @@
 packages = [
   { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
   { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleamy_bench", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleamy_bench", source = "hex", outer_checksum = "DEF68E4B097A56781282F0F9D48371A0ABBCDDCF89CAD05B28C3BEDD6B2E8DF3" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.43.0 and < 1.0.0" }
+gleamy_bench = { version = ">= 0.6.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.1" }
 simplifile = { version = ">= 1.0.0 and < 3.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,6 +7,7 @@ packages = [
   { name = "gleamy_bench", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleamy_bench", source = "hex", outer_checksum = "DEF68E4B097A56781282F0F9D48371A0ABBCDDCF89CAD05B28C3BEDD6B2E8DF3" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
+  { name = "splitter", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "05564A381580395DCDEFF4F88A64B021E8DAFA6540AE99B4623962F52976AA9D" },
 ]
 
 [requirements]
@@ -14,3 +15,4 @@ gleam_stdlib = { version = ">= 0.43.0 and < 1.0.0" }
 gleamy_bench = { version = ">= 0.6.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.1" }
 simplifile = { version = ">= 1.0.0 and < 3.0.0" }
+splitter = { version = ">= 1.1.0 and < 2.0.0" }

--- a/src/glexer.ffi.mjs
+++ b/src/glexer.ffi.mjs
@@ -5,3 +5,7 @@ export function slice_bytes(string, start, size) {
 export function drop_byte(string) {
   return string.slice(1);
 }
+
+export function string_length(string) {
+  return string.length;
+}

--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -30,7 +30,12 @@ type LexerMode {
 }
 
 pub type Position {
-  Position(byte_offset: Int)
+  Position(
+    /// Despite being named 'byte_offset', this isn't actually a 'byte_offset'
+    /// on JavaScript. Strings on JavaScript are utf-16, so this is actually
+    /// more like a 'codeunit' offset.
+    byte_offset: Int,
+  )
 }
 
 pub fn new(source: String) -> Lexer {
@@ -366,7 +371,7 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
                 lexer,
                 token.UnexpectedGrapheme(grapheme),
                 source,
-                string.byte_size(grapheme),
+                length(grapheme),
               )
             }
           }
@@ -592,7 +597,7 @@ fn whitespace(
 fn skip_comment(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
   let #(prefix, suffix) = splitter.split_before(lexer.newlines, lexer.source)
 
-  let eaten = string.byte_size(prefix)
+  let eaten = length(prefix)
   let lexer = advance(lexer, suffix, eaten)
 
   next(lexer)
@@ -605,7 +610,7 @@ fn comment(
 ) -> #(Lexer, #(Token, Position)) {
   let #(prefix, suffix) = splitter.split_before(lexer.newlines, lexer.source)
 
-  let eaten = string.byte_size(prefix)
+  let eaten = length(prefix)
   let lexer = advance(lexer, suffix, eaten)
 
   let token = case kind {
@@ -774,7 +779,7 @@ fn lex_string(
           |> lex_string(start, slice_size + 1)
 
         Ok(#(grapheme, source)) -> {
-          let offset = 1 + string.byte_size(grapheme)
+          let offset = 1 + length(grapheme)
           advance(lexer, source, offset)
           |> lex_string(start, slice_size + offset)
         }
@@ -882,6 +887,11 @@ fn token(lexer: Lexer, token: Token, source: String, offset: Int) {
 // //////////////////// //
 // FFI String functions //
 // //////////////////// //
+
+@external(javascript, "./glexer.ffi.mjs", "string_length")
+fn length(string: String) -> Int {
+  string.byte_size(string)
+}
 
 /// > 🚨 Beware that this is tricking Gleam's type system! There's no guarantee
 /// > that taking a slice from an arbitrary byte index would result in a valid

--- a/test/glexer/benchmark.gleam
+++ b/test/glexer/benchmark.gleam
@@ -1,0 +1,26 @@
+import gleam/io
+import gleam/string
+import gleamy/bench
+import glexer
+import simplifile
+
+pub fn main() {
+  let assert Ok(source) =
+    simplifile.read("./build/packages/gleam_stdlib/src/gleam/list.gleam")
+
+  let source_x1 = source |> string.repeat(1)
+  let source_x10 = source |> string.repeat(10)
+  let source_x100 = source |> string.repeat(100)
+
+  bench.run(
+    [
+      bench.Input("src x1", source_x1),
+      bench.Input("src x10", source_x10),
+      bench.Input("src x100", source_x100),
+    ],
+    [bench.Function("lex", fn(source) { glexer.new(source) |> glexer.lex })],
+    [bench.Duration(5000), bench.Warmup(100)],
+  )
+  |> bench.table([bench.IPS, bench.Min, bench.P(99)])
+  |> io.println
+}


### PR DESCRIPTION
```
Erlang before:
Input               Function                       IPS           Min           P99
src x1              lex                       149.8624        5.8311        7.9632
src x10             lex                         8.1232      116.2380      129.0588
src x100            lex                         0.6243     1573.7399     1619.6338

Erlang after:
Input               Function                       IPS           Min           P99
src x1              lex                       206.4645        2.9487       12.2394
src x10             lex                        11.2916       82.5204       93.2181
src x100            lex                         0.9157     1013.1796     1227.5787
```

```
JavaScript before:
Input               Function                       IPS           Min           P99
src x1              lex                       181.6950        4.8682        8.2740
src x10             lex                        15.1156       60.2604       88.8290
src x100            lex                         1.0879      835.8635      976.3370

JavaScript after:
Input               Function                       IPS           Min           P99
src x1              lex                       186.3590        4.6623       10.0757
src x10             lex                        15.7126       56.5029      196.4822
src x100            lex                         1.0891      829.2348      988.8560
```