### PR TITLE
Refactor `next` and friends such that gleam knows how to tail-call-optimize the javascript, fixing stack overflow issue

### DIFF
--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -1,5 +1,6 @@
 import gleam/int
 import gleam/list
+import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import glexer/token.{type Token}
@@ -65,8 +66,9 @@ pub fn lex(lexer: Lexer) -> List(#(Token, Position)) {
 
 fn do_lex(lexer: Lexer, tokens: List(#(Token, Position))) {
   case next(lexer) {
-    #(_lexer, #(token.EndOfFile, _)) -> tokens
-    #(lexer, token) -> do_lex(lexer, [token, ..tokens])
+    #(lexer, None) -> do_lex(lexer, tokens)
+    #(_lexer, Some(#(token.EndOfFile, _))) -> tokens
+    #(lexer, Some(token)) -> do_lex(lexer, [token, ..tokens])
   }
 }
 
@@ -76,27 +78,27 @@ type CommentKind {
   ModuleComment
 }
 
-fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
+fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.mode {
     CheckForMinus ->
       case check_for_minus(lexer) {
-        Ok(#(lexer, token)) -> #(lexer, token)
-        Error(Nil) -> next(Lexer(..lexer, mode: Normal))
+        Ok(#(lexer, token)) -> #(lexer, Some(token))
+        Error(Nil) -> #(Lexer(..lexer, mode: Normal), None)
       }
 
     CheckForNestedDot ->
       case check_for_nested_dot(lexer) {
-        Ok(#(lexer, token)) -> #(lexer, token)
-        Error(Nil) -> next(Lexer(..lexer, mode: Normal))
+        Ok(#(lexer, token)) -> #(lexer, Some(token))
+        Error(Nil) -> #(Lexer(..lexer, mode: Normal), None)
       }
 
     CheckForNestedDotOrMinus ->
       case check_for_nested_dot(lexer) {
-        Ok(#(lexer, token)) -> #(lexer, token)
+        Ok(#(lexer, token)) -> #(lexer, Some(token))
         Error(Nil) ->
           case check_for_minus(lexer) {
-            Ok(#(lexer, token)) -> #(lexer, token)
-            Error(Nil) -> next(Lexer(..lexer, mode: Normal))
+            Ok(#(lexer, token)) -> #(lexer, Some(token))
+            Error(Nil) -> #(Lexer(..lexer, mode: Normal), None)
           }
       }
 
@@ -118,10 +120,10 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
             |> lex_digits(byte_offset, 1)
 
           let lexer = Lexer(..lexer, mode: CheckForNestedDot)
-          #(lexer, #(token.Int(int), Position(byte_offset:)))
+          #(lexer, Some(#(token.Int(int), Position(byte_offset:))))
         }
 
-        _ -> next(Lexer(..lexer, mode: Normal))
+        _ -> #(Lexer(..lexer, mode: Normal), None)
       }
 
     Normal ->
@@ -138,6 +140,7 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
             True ->
               advance(lexer, source, 4)
               |> comment(ModuleComment, lexer.byte_offset)
+              |> wrap_token
           }
 
         "///" <> source ->
@@ -146,6 +149,7 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
             True ->
               advance(lexer, source, 3)
               |> comment(DocComment, lexer.byte_offset)
+              |> wrap_token
           }
 
         "//" <> source ->
@@ -154,59 +158,66 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
             True ->
               advance(lexer, source, 2)
               |> comment(RegularComment, lexer.byte_offset)
+              |> wrap_token
           }
 
         // Groupings
-        "(" <> source -> token(lexer, token.LeftParen, source, 1)
-        ")" <> source -> token(lexer, token.RightParen, source, 1)
-        "{" <> source -> token(lexer, token.LeftBrace, source, 1)
-        "}" <> source -> token(lexer, token.RightBrace, source, 1)
-        "[" <> source -> token(lexer, token.LeftSquare, source, 1)
-        "]" <> source -> token(lexer, token.RightSquare, source, 1)
+        "(" <> source -> wrap_token(token(lexer, token.LeftParen, source, 1))
+        ")" <> source -> wrap_token(token(lexer, token.RightParen, source, 1))
+        "{" <> source -> wrap_token(token(lexer, token.LeftBrace, source, 1))
+        "}" <> source -> wrap_token(token(lexer, token.RightBrace, source, 1))
+        "[" <> source -> wrap_token(token(lexer, token.LeftSquare, source, 1))
+        "]" <> source -> wrap_token(token(lexer, token.RightSquare, source, 1))
 
         // Other Punctuation
-        "@" <> source -> token(lexer, token.At, source, 1)
-        ":" <> source -> token(lexer, token.Colon, source, 1)
-        "," <> source -> token(lexer, token.Comma, source, 1)
-        ".." <> source -> token(lexer, token.DotDot, source, 2)
-        "." <> source -> token(lexer, token.Dot, source, 1)
-        "#" <> source -> token(lexer, token.Hash, source, 1)
-        "!=" <> source -> token(lexer, token.NotEqual, source, 2)
-        "!" <> source -> token(lexer, token.Bang, source, 1)
-        "==" <> source -> token(lexer, token.EqualEqual, source, 2)
-        "=" <> source -> token(lexer, token.Equal, source, 1)
-        "|>" <> source -> token(lexer, token.Pipe, source, 2)
-        "||" <> source -> token(lexer, token.VBarVBar, source, 2)
-        "|" <> source -> token(lexer, token.VBar, source, 1)
-        "&&" <> source -> token(lexer, token.AmperAmper, source, 2)
-        "<<" <> source -> token(lexer, token.LessLess, source, 2)
-        ">>" <> source -> token(lexer, token.GreaterGreater, source, 2)
-        "<-" <> source -> token(lexer, token.LeftArrow, source, 2)
-        "->" <> source -> token(lexer, token.RightArrow, source, 2)
+        "@" <> source -> wrap_token(token(lexer, token.At, source, 1))
+        ":" <> source -> wrap_token(token(lexer, token.Colon, source, 1))
+        "," <> source -> wrap_token(token(lexer, token.Comma, source, 1))
+        ".." <> source -> wrap_token(token(lexer, token.DotDot, source, 2))
+        "." <> source -> wrap_token(token(lexer, token.Dot, source, 1))
+        "#" <> source -> wrap_token(token(lexer, token.Hash, source, 1))
+        "!=" <> source -> wrap_token(token(lexer, token.NotEqual, source, 2))
+        "!" <> source -> wrap_token(token(lexer, token.Bang, source, 1))
+        "==" <> source -> wrap_token(token(lexer, token.EqualEqual, source, 2))
+        "=" <> source -> wrap_token(token(lexer, token.Equal, source, 1))
+        "|>" <> source -> wrap_token(token(lexer, token.Pipe, source, 2))
+        "||" <> source -> wrap_token(token(lexer, token.VBarVBar, source, 2))
+        "|" <> source -> wrap_token(token(lexer, token.VBar, source, 1))
+        "&&" <> source -> wrap_token(token(lexer, token.AmperAmper, source, 2))
+        "<<" <> source -> wrap_token(token(lexer, token.LessLess, source, 2))
+        ">>" <> source ->
+          wrap_token(token(lexer, token.GreaterGreater, source, 2))
+        "<-" <> source -> wrap_token(token(lexer, token.LeftArrow, source, 2))
+        "->" <> source -> wrap_token(token(lexer, token.RightArrow, source, 2))
 
         // String Operators
-        "<>" <> source -> token(lexer, token.LessGreater, source, 2)
+        "<>" <> source -> wrap_token(token(lexer, token.LessGreater, source, 2))
 
         // Float Operators
-        "+." <> source -> token(lexer, token.PlusDot, source, 2)
-        "-." <> source -> token(lexer, token.MinusDot, source, 2)
-        "*." <> source -> token(lexer, token.StarDot, source, 2)
-        "/." <> source -> token(lexer, token.SlashDot, source, 2)
-        "<=." <> source -> token(lexer, token.LessEqualDot, source, 3)
-        "<." <> source -> token(lexer, token.LessDot, source, 2)
-        ">=." <> source -> token(lexer, token.GreaterEqualDot, source, 3)
-        ">." <> source -> token(lexer, token.GreaterDot, source, 2)
+        "+." <> source -> wrap_token(token(lexer, token.PlusDot, source, 2))
+        "-." <> source -> wrap_token(token(lexer, token.MinusDot, source, 2))
+        "*." <> source -> wrap_token(token(lexer, token.StarDot, source, 2))
+        "/." <> source -> wrap_token(token(lexer, token.SlashDot, source, 2))
+        "<=." <> source ->
+          wrap_token(token(lexer, token.LessEqualDot, source, 3))
+        "<." <> source -> wrap_token(token(lexer, token.LessDot, source, 2))
+        ">=." <> source ->
+          wrap_token(token(lexer, token.GreaterEqualDot, source, 3))
+        ">." <> source -> wrap_token(token(lexer, token.GreaterDot, source, 2))
 
         // Binary/Octal/Hexadecimal
         "0b" <> source ->
           advance(lexer, source, 2)
           |> lex_binary(lexer.byte_offset, 2)
+          |> wrap_token
         "0o" <> source ->
           advance(lexer, source, 2)
           |> lex_octal(lexer.byte_offset, 2)
+          |> wrap_token
         "0x" <> source ->
           advance(lexer, source, 2)
           |> lex_hexadecimal(lexer.byte_offset, 2)
+          |> wrap_token
 
         // Decimal Numbers
         "0" <> source
@@ -221,6 +232,7 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
         | "9" <> source -> {
           advance(lexer, source, 1)
           |> lex_number(LexInt, lexer.byte_offset, 1)
+          |> wrap_token
         }
 
         "-0" <> source
@@ -235,23 +247,26 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
         | "-9" <> source -> {
           advance(lexer, source, 2)
           |> lex_number(LexInt, lexer.byte_offset, 2)
+          |> wrap_token
         }
 
         // Int Operators
-        "+" <> source -> token(lexer, token.Plus, source, 1)
-        "-" <> source -> token(lexer, token.Minus, source, 1)
-        "*" <> source -> token(lexer, token.Star, source, 1)
-        "/" <> source -> token(lexer, token.Slash, source, 1)
-        "<=" <> source -> token(lexer, token.LessEqual, source, 2)
-        "<" <> source -> token(lexer, token.Less, source, 1)
-        ">=" <> source -> token(lexer, token.GreaterEqual, source, 2)
-        ">" <> source -> token(lexer, token.Greater, source, 1)
-        "%" <> source -> token(lexer, token.Percent, source, 1)
+        "+" <> source -> wrap_token(token(lexer, token.Plus, source, 1))
+        "-" <> source -> wrap_token(token(lexer, token.Minus, source, 1))
+        "*" <> source -> wrap_token(token(lexer, token.Star, source, 1))
+        "/" <> source -> wrap_token(token(lexer, token.Slash, source, 1))
+        "<=" <> source -> wrap_token(token(lexer, token.LessEqual, source, 2))
+        "<" <> source -> wrap_token(token(lexer, token.Less, source, 1))
+        ">=" <> source ->
+          wrap_token(token(lexer, token.GreaterEqual, source, 2))
+        ">" <> source -> wrap_token(token(lexer, token.Greater, source, 1))
+        "%" <> source -> wrap_token(token(lexer, token.Percent, source, 1))
 
         // Strings
         "\"" <> source ->
           advance(lexer, source, 1)
           |> lex_string(lexer.byte_offset, 0)
+          |> wrap_token
 
         // Discard
         "_" <> source -> {
@@ -260,7 +275,7 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
             advance(lexer, source, 1)
             |> lex_lowercase_name(byte_offset + 1, 0)
 
-          #(lexer, #(token.DiscardName(name), Position(byte_offset:)))
+          #(lexer, Some(#(token.DiscardName(name), Position(byte_offset:))))
         }
 
         // Keywords & Literals (Lowercase)
@@ -323,7 +338,7 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
 
           let lexer = Lexer(..lexer, mode: CheckForNestedDotOrMinus)
 
-          #(lexer, #(token, Position(byte_offset:)))
+          #(lexer, Some(#(token, Position(byte_offset:))))
         }
 
         // Uppercase Name
@@ -358,21 +373,24 @@ fn next(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
             advance(lexer, source, 1)
             |> lex_uppercase_name(byte_offset, 1)
 
-          #(lexer, #(token.UpperName(name), Position(byte_offset:)))
+          #(lexer, Some(#(token.UpperName(name), Position(byte_offset:))))
         }
 
         _ ->
           case string.pop_grapheme(lexer.source) {
             // We've hit the end of the file
-            Error(_) -> #(lexer, #(token.EndOfFile, Position(lexer.byte_offset)))
+            Error(_) -> #(
+              lexer,
+              Some(#(token.EndOfFile, Position(lexer.byte_offset))),
+            )
             // This grapheme was unexpected
             Ok(#(grapheme, source)) -> {
-              token(
+              wrap_token(token(
                 lexer,
                 token.UnexpectedGrapheme(grapheme),
                 source,
                 length(grapheme),
-              )
+              ))
             }
           }
       }
@@ -574,7 +592,7 @@ fn whitespace(
   lexer: Lexer,
   start: Int,
   slice_size: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.source {
     " " <> source | "\t" <> source | "\n" <> source | "\r" <> source ->
       advance(lexer, source, 1)
@@ -582,25 +600,32 @@ fn whitespace(
 
     _ ->
       case lexer.preserve_whitespace {
-        False -> next(lexer)
+        False -> #(lexer, None)
         True -> {
           let content = slice_bytes(lexer.original_source, start, slice_size)
-          #(lexer, #(token.Space(content), Position(byte_offset: start)))
+          #(lexer, Some(#(token.Space(content), Position(byte_offset: start))))
         }
       }
   }
 }
 
-/// Ignores the rest of the line until it finds a newline, and returns the next
-/// token.
+/// Ignores the rest of the line until it finds a newline, and signals the
+/// caller to continue lexing.
 ///
-fn skip_comment(lexer: Lexer) -> #(Lexer, #(Token, Position)) {
+fn skip_comment(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
   let #(prefix, suffix) = splitter.split_before(lexer.newlines, lexer.source)
 
   let eaten = length(prefix)
   let lexer = advance(lexer, suffix, eaten)
 
-  next(lexer)
+  #(lexer, None)
+}
+
+fn wrap_token(
+  result: #(Lexer, #(Token, Position)),
+) -> #(Lexer, Option(#(Token, Position))) {
+  let #(lexer, token) = result
+  #(lexer, Some(token))
 }
 
 fn comment(

--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -82,22 +82,22 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.mode {
     CheckForMinus ->
       case check_for_minus(lexer) {
-        Ok(#(lexer, token)) -> #(lexer, Some(token))
+        Ok(result) -> result
         Error(Nil) -> #(Lexer(..lexer, mode: Normal), None)
       }
 
     CheckForNestedDot ->
       case check_for_nested_dot(lexer) {
-        Ok(#(lexer, token)) -> #(lexer, Some(token))
+        Ok(result) -> result
         Error(Nil) -> #(Lexer(..lexer, mode: Normal), None)
       }
 
     CheckForNestedDotOrMinus ->
       case check_for_nested_dot(lexer) {
-        Ok(#(lexer, token)) -> #(lexer, Some(token))
+        Ok(result) -> result
         Error(Nil) ->
           case check_for_minus(lexer) {
-            Ok(#(lexer, token)) -> #(lexer, Some(token))
+            Ok(result) -> result
             Error(Nil) -> #(Lexer(..lexer, mode: Normal), None)
           }
       }
@@ -140,7 +140,6 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
             True ->
               advance(lexer, source, 4)
               |> comment(ModuleComment, lexer.byte_offset)
-              |> wrap_token
           }
 
         "///" <> source ->
@@ -149,7 +148,6 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
             True ->
               advance(lexer, source, 3)
               |> comment(DocComment, lexer.byte_offset)
-              |> wrap_token
           }
 
         "//" <> source ->
@@ -158,66 +156,59 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
             True ->
               advance(lexer, source, 2)
               |> comment(RegularComment, lexer.byte_offset)
-              |> wrap_token
           }
 
         // Groupings
-        "(" <> source -> wrap_token(token(lexer, token.LeftParen, source, 1))
-        ")" <> source -> wrap_token(token(lexer, token.RightParen, source, 1))
-        "{" <> source -> wrap_token(token(lexer, token.LeftBrace, source, 1))
-        "}" <> source -> wrap_token(token(lexer, token.RightBrace, source, 1))
-        "[" <> source -> wrap_token(token(lexer, token.LeftSquare, source, 1))
-        "]" <> source -> wrap_token(token(lexer, token.RightSquare, source, 1))
+        "(" <> source -> token(lexer, token.LeftParen, source, 1)
+        ")" <> source -> token(lexer, token.RightParen, source, 1)
+        "{" <> source -> token(lexer, token.LeftBrace, source, 1)
+        "}" <> source -> token(lexer, token.RightBrace, source, 1)
+        "[" <> source -> token(lexer, token.LeftSquare, source, 1)
+        "]" <> source -> token(lexer, token.RightSquare, source, 1)
 
         // Other Punctuation
-        "@" <> source -> wrap_token(token(lexer, token.At, source, 1))
-        ":" <> source -> wrap_token(token(lexer, token.Colon, source, 1))
-        "," <> source -> wrap_token(token(lexer, token.Comma, source, 1))
-        ".." <> source -> wrap_token(token(lexer, token.DotDot, source, 2))
-        "." <> source -> wrap_token(token(lexer, token.Dot, source, 1))
-        "#" <> source -> wrap_token(token(lexer, token.Hash, source, 1))
-        "!=" <> source -> wrap_token(token(lexer, token.NotEqual, source, 2))
-        "!" <> source -> wrap_token(token(lexer, token.Bang, source, 1))
-        "==" <> source -> wrap_token(token(lexer, token.EqualEqual, source, 2))
-        "=" <> source -> wrap_token(token(lexer, token.Equal, source, 1))
-        "|>" <> source -> wrap_token(token(lexer, token.Pipe, source, 2))
-        "||" <> source -> wrap_token(token(lexer, token.VBarVBar, source, 2))
-        "|" <> source -> wrap_token(token(lexer, token.VBar, source, 1))
-        "&&" <> source -> wrap_token(token(lexer, token.AmperAmper, source, 2))
-        "<<" <> source -> wrap_token(token(lexer, token.LessLess, source, 2))
-        ">>" <> source ->
-          wrap_token(token(lexer, token.GreaterGreater, source, 2))
-        "<-" <> source -> wrap_token(token(lexer, token.LeftArrow, source, 2))
-        "->" <> source -> wrap_token(token(lexer, token.RightArrow, source, 2))
+        "@" <> source -> token(lexer, token.At, source, 1)
+        ":" <> source -> token(lexer, token.Colon, source, 1)
+        "," <> source -> token(lexer, token.Comma, source, 1)
+        ".." <> source -> token(lexer, token.DotDot, source, 2)
+        "." <> source -> token(lexer, token.Dot, source, 1)
+        "#" <> source -> token(lexer, token.Hash, source, 1)
+        "!=" <> source -> token(lexer, token.NotEqual, source, 2)
+        "!" <> source -> token(lexer, token.Bang, source, 1)
+        "==" <> source -> token(lexer, token.EqualEqual, source, 2)
+        "=" <> source -> token(lexer, token.Equal, source, 1)
+        "|>" <> source -> token(lexer, token.Pipe, source, 2)
+        "||" <> source -> token(lexer, token.VBarVBar, source, 2)
+        "|" <> source -> token(lexer, token.VBar, source, 1)
+        "&&" <> source -> token(lexer, token.AmperAmper, source, 2)
+        "<<" <> source -> token(lexer, token.LessLess, source, 2)
+        ">>" <> source -> token(lexer, token.GreaterGreater, source, 2)
+        "<-" <> source -> token(lexer, token.LeftArrow, source, 2)
+        "->" <> source -> token(lexer, token.RightArrow, source, 2)
 
         // String Operators
-        "<>" <> source -> wrap_token(token(lexer, token.LessGreater, source, 2))
+        "<>" <> source -> token(lexer, token.LessGreater, source, 2)
 
         // Float Operators
-        "+." <> source -> wrap_token(token(lexer, token.PlusDot, source, 2))
-        "-." <> source -> wrap_token(token(lexer, token.MinusDot, source, 2))
-        "*." <> source -> wrap_token(token(lexer, token.StarDot, source, 2))
-        "/." <> source -> wrap_token(token(lexer, token.SlashDot, source, 2))
-        "<=." <> source ->
-          wrap_token(token(lexer, token.LessEqualDot, source, 3))
-        "<." <> source -> wrap_token(token(lexer, token.LessDot, source, 2))
-        ">=." <> source ->
-          wrap_token(token(lexer, token.GreaterEqualDot, source, 3))
-        ">." <> source -> wrap_token(token(lexer, token.GreaterDot, source, 2))
+        "+." <> source -> token(lexer, token.PlusDot, source, 2)
+        "-." <> source -> token(lexer, token.MinusDot, source, 2)
+        "*." <> source -> token(lexer, token.StarDot, source, 2)
+        "/." <> source -> token(lexer, token.SlashDot, source, 2)
+        "<=." <> source -> token(lexer, token.LessEqualDot, source, 3)
+        "<." <> source -> token(lexer, token.LessDot, source, 2)
+        ">=." <> source -> token(lexer, token.GreaterEqualDot, source, 3)
+        ">." <> source -> token(lexer, token.GreaterDot, source, 2)
 
         // Binary/Octal/Hexadecimal
         "0b" <> source ->
           advance(lexer, source, 2)
           |> lex_binary(lexer.byte_offset, 2)
-          |> wrap_token
         "0o" <> source ->
           advance(lexer, source, 2)
           |> lex_octal(lexer.byte_offset, 2)
-          |> wrap_token
         "0x" <> source ->
           advance(lexer, source, 2)
           |> lex_hexadecimal(lexer.byte_offset, 2)
-          |> wrap_token
 
         // Decimal Numbers
         "0" <> source
@@ -232,7 +223,6 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
         | "9" <> source -> {
           advance(lexer, source, 1)
           |> lex_number(LexInt, lexer.byte_offset, 1)
-          |> wrap_token
         }
 
         "-0" <> source
@@ -247,26 +237,23 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
         | "-9" <> source -> {
           advance(lexer, source, 2)
           |> lex_number(LexInt, lexer.byte_offset, 2)
-          |> wrap_token
         }
 
         // Int Operators
-        "+" <> source -> wrap_token(token(lexer, token.Plus, source, 1))
-        "-" <> source -> wrap_token(token(lexer, token.Minus, source, 1))
-        "*" <> source -> wrap_token(token(lexer, token.Star, source, 1))
-        "/" <> source -> wrap_token(token(lexer, token.Slash, source, 1))
-        "<=" <> source -> wrap_token(token(lexer, token.LessEqual, source, 2))
-        "<" <> source -> wrap_token(token(lexer, token.Less, source, 1))
-        ">=" <> source ->
-          wrap_token(token(lexer, token.GreaterEqual, source, 2))
-        ">" <> source -> wrap_token(token(lexer, token.Greater, source, 1))
-        "%" <> source -> wrap_token(token(lexer, token.Percent, source, 1))
+        "+" <> source -> token(lexer, token.Plus, source, 1)
+        "-" <> source -> token(lexer, token.Minus, source, 1)
+        "*" <> source -> token(lexer, token.Star, source, 1)
+        "/" <> source -> token(lexer, token.Slash, source, 1)
+        "<=" <> source -> token(lexer, token.LessEqual, source, 2)
+        "<" <> source -> token(lexer, token.Less, source, 1)
+        ">=" <> source -> token(lexer, token.GreaterEqual, source, 2)
+        ">" <> source -> token(lexer, token.Greater, source, 1)
+        "%" <> source -> token(lexer, token.Percent, source, 1)
 
         // Strings
         "\"" <> source ->
           advance(lexer, source, 1)
           |> lex_string(lexer.byte_offset, 0)
-          |> wrap_token
 
         // Discard
         "_" <> source -> {
@@ -385,12 +372,12 @@ fn next(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
             )
             // This grapheme was unexpected
             Ok(#(grapheme, source)) -> {
-              wrap_token(token(
+              token(
                 lexer,
                 token.UnexpectedGrapheme(grapheme),
                 source,
                 length(grapheme),
-              ))
+              )
             }
           }
       }
@@ -547,7 +534,9 @@ fn lex_uppercase_name(
   }
 }
 
-fn check_for_minus(lexer: Lexer) -> Result(#(Lexer, #(Token, Position)), Nil) {
+fn check_for_minus(
+  lexer: Lexer,
+) -> Result(#(Lexer, Option(#(Token, Position))), Nil) {
   case lexer.source {
     "-" <> source -> {
       let #(lexer, token) = token(lexer, token.Minus, source, 1)
@@ -561,9 +550,12 @@ fn check_for_minus(lexer: Lexer) -> Result(#(Lexer, #(Token, Position)), Nil) {
 
 fn check_for_nested_dot(
   lexer: Lexer,
-) -> Result(#(Lexer, #(Token, Position)), Nil) {
+) -> Result(#(Lexer, Option(#(Token, Position))), Nil) {
   case lexer.source {
-    ".." <> source -> Ok(token(lexer, token.DotDot, source, 2))
+    ".." <> source -> {
+      let #(lexer, token) = token(lexer, token.DotDot, source, 2)
+      Ok(#(lexer, token))
+    }
     "." <> source -> {
       case source {
         "0" <> _
@@ -580,7 +572,10 @@ fn check_for_nested_dot(
 
           Ok(#(Lexer(..lexer, mode: HasNestedDot), token))
         }
-        _ -> Ok(token(lexer, token.Dot, source, 1))
+        _ -> {
+          let #(lexer, token) = token(lexer, token.Dot, source, 1)
+          Ok(#(lexer, token))
+        }
       }
     }
 
@@ -621,7 +616,7 @@ fn skip_comment(lexer: Lexer) -> #(Lexer, Option(#(Token, Position))) {
   #(lexer, None)
 }
 
-fn wrap_token(
+fn some_token(
   result: #(Lexer, #(Token, Position)),
 ) -> #(Lexer, Option(#(Token, Position))) {
   let #(lexer, token) = result
@@ -632,7 +627,7 @@ fn comment(
   lexer: Lexer,
   kind: CommentKind,
   start: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   let #(prefix, suffix) = splitter.split_before(lexer.newlines, lexer.source)
 
   let eaten = length(prefix)
@@ -644,14 +639,14 @@ fn comment(
     RegularComment -> token.CommentNormal(prefix)
   }
 
-  #(lexer, #(token, Position(byte_offset: start)))
+  #(lexer, Some(#(token, Position(byte_offset: start))))
 }
 
 fn lex_binary(
   lexer: Lexer,
   start: Int,
   slice_size: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.source {
     "_" <> source | "0" <> source | "1" <> source ->
       advance(lexer, source, 1)
@@ -659,7 +654,7 @@ fn lex_binary(
 
     _ -> {
       let content = slice_bytes(lexer.original_source, start, slice_size)
-      #(lexer, #(token.Int(content), Position(byte_offset: start)))
+      #(lexer, Some(#(token.Int(content), Position(byte_offset: start))))
     }
   }
 }
@@ -668,7 +663,7 @@ fn lex_octal(
   lexer: Lexer,
   start: Int,
   slice_size: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.source {
     "_" <> source
     | "0" <> source
@@ -684,7 +679,7 @@ fn lex_octal(
 
     _ -> {
       let content = slice_bytes(lexer.original_source, start, slice_size)
-      #(lexer, #(token.Int(content), Position(byte_offset: start)))
+      #(lexer, Some(#(token.Int(content), Position(byte_offset: start))))
     }
   }
 }
@@ -693,7 +688,7 @@ fn lex_hexadecimal(
   lexer: Lexer,
   start: Int,
   slice_size: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.source {
     "_" <> source
     | "0" <> source
@@ -723,7 +718,7 @@ fn lex_hexadecimal(
 
     _ -> {
       let content = slice_bytes(lexer.original_source, start, slice_size)
-      #(lexer, #(token.Int(content), Position(byte_offset: start)))
+      #(lexer, Some(#(token.Int(content), Position(byte_offset: start))))
     }
   }
 }
@@ -739,7 +734,7 @@ fn lex_number(
   mode: LexNumberMode,
   start: Int,
   slice_size: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.source, mode {
     "_" <> source, _
     | "0" <> source, _
@@ -774,13 +769,13 @@ fn lex_number(
     _, LexInt -> {
       let lexer = Lexer(..lexer, mode: CheckForMinus)
       let content = slice_bytes(lexer.original_source, start, slice_size)
-      #(lexer, #(token.Int(content), Position(byte_offset: start)))
+      #(lexer, Some(#(token.Int(content), Position(byte_offset: start))))
     }
 
     _, LexFloat | _, LexFloatExponent -> {
       let lexer = Lexer(..lexer, mode: CheckForMinus)
       let content = slice_bytes(lexer.original_source, start, slice_size)
-      #(lexer, #(token.Float(content), Position(byte_offset: start)))
+      #(lexer, Some(#(token.Float(content), Position(byte_offset: start))))
     }
   }
 }
@@ -789,12 +784,13 @@ fn lex_string(
   lexer: Lexer,
   start: Int,
   slice_size: Int,
-) -> #(Lexer, #(Token, Position)) {
+) -> #(Lexer, Option(#(Token, Position))) {
   case lexer.source {
     "\"" <> source -> {
       let content = slice_bytes(lexer.original_source, start + 1, slice_size)
       #(token.String(content), Position(byte_offset: start))
       |> advanced(lexer, source, 1)
+      |> some_token
     }
 
     "\\" <> source ->
@@ -812,10 +808,10 @@ fn lex_string(
 
     "" -> {
       let content = slice_bytes(lexer.original_source, start + 1, slice_size)
-      #(lexer, #(
-        token.UnterminatedString(content),
-        Position(byte_offset: start),
-      ))
+      #(
+        lexer,
+        Some(#(token.UnterminatedString(content), Position(byte_offset: start))),
+      )
     }
 
     _ ->
@@ -904,9 +900,15 @@ fn advanced(
   #(advance(lexer, source, offset), token)
 }
 
-fn token(lexer: Lexer, token: Token, source: String, offset: Int) {
+fn token(
+  lexer: Lexer,
+  token: Token,
+  source: String,
+  offset: Int,
+) -> #(Lexer, Option(#(Token, Position))) {
   #(token, Position(byte_offset: lexer.byte_offset))
   |> advanced(lexer, source, offset)
+  |> some_token
 }
 
 // //////////////////// //

--- a/src/glexer.gleam
+++ b/src/glexer.gleam
@@ -552,10 +552,7 @@ fn check_for_nested_dot(
   lexer: Lexer,
 ) -> Result(#(Lexer, Option(#(Token, Position))), Nil) {
   case lexer.source {
-    ".." <> source -> {
-      let #(lexer, token) = token(lexer, token.DotDot, source, 2)
-      Ok(#(lexer, token))
-    }
+    ".." <> source -> Ok(token(lexer, token.DotDot, source, 2))
     "." <> source -> {
       case source {
         "0" <> _
@@ -572,10 +569,7 @@ fn check_for_nested_dot(
 
           Ok(#(Lexer(..lexer, mode: HasNestedDot), token))
         }
-        _ -> {
-          let #(lexer, token) = token(lexer, token.Dot, source, 1)
-          Ok(#(lexer, token))
-        }
+        _ -> Ok(token(lexer, token.Dot, source, 1))
       }
     }
 


### PR DESCRIPTION
When using glexer (compiled to javascript) on large enough files I was getting MaximumCallStack errors. This refactor changes `next` to be non-recursive, instead returning `None` as the second tuple item when recursion would previously happen. `do_lex` then uses that cue to itself recurse. Critically, do_lex is simple enough that gleam is able to compile away the recursion, producing a while loop and eliminating the stack overflow error.

Let me know if you'd like me to switch to a more explicit type, like `type LexResult { Continue(Lexer) | Token(Lexer, #(Token, Position)) }` or something like that. I figured this was simple enough, but the other way might be clearer.