### PR TITLE
update deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         otp-version: ["27", "28"]
-        gleam-version: ["1.10", "1.11", "1.12"]
+        gleam-version: ["1.14", "1.15"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         node-version: ["20", "22", "24"]
-        gleam-version: ["1.10", "1.11", "1.12"]
+        gleam-version: ["1.14", "1.15"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         deno-version: ["v1.x", "v2.x"]
-        gleam-version: ["1.10", "1.11", "1.12"]
+        gleam-version: ["1.14", "1.15"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         bun-version: ["latest"]
-        gleam-version: ["1.10", "1.11", "1.12"]
+        gleam-version: ["1.14", "1.15"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-   Updated the `gleam_stdlib` version constraint to allow using `v1.0.0`
+
 ## [2.3.1] - 2026-01-23
 
 -   Fixed a stack overflow when running on the V8 JavaScript engine

--- a/gleam.toml
+++ b/gleam.toml
@@ -9,7 +9,7 @@ repository = { type = "github", user = "DanielleMaywood", repo = "glexer" }
 allow_read = true
 
 [dependencies]
-gleam_stdlib = ">= 0.43.0 and < 1.0.0"
+gleam_stdlib = ">= 0.43.0 and < 2.0.0"
 splitter = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,16 +2,16 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
-  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
   { name = "gleamy_bench", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleamy_bench", source = "hex", outer_checksum = "DEF68E4B097A56781282F0F9D48371A0ABBCDDCF89CAD05B28C3BEDD6B2E8DF3" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
-  { name = "splitter", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "05564A381580395DCDEFF4F88A64B021E8DAFA6540AE99B4623962F52976AA9D" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.43.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.43.0 and < 2.0.0" }
 gleamy_bench = { version = ">= 0.6.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.1" }
 simplifile = { version = ">= 1.0.0 and < 3.0.0" }


### PR DESCRIPTION
This PR updates the `gleam_stdlib` version constraint to allow using `v1.0.0` (and I've bumped the gleam version on ci!)